### PR TITLE
Feat: Implement exponential soft-cap upgrade scaling

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -47,7 +47,7 @@ function love.draw()
     UI.drawHUD(Player.data, Game.getPlayerRealm())
     UI.drawInventory(Player.data.gold, Player.data.essence.tier1, Player.data.essence.tier2)
     UI.drawRealmList(Game.getRealmsTable(), Game.getPlayerRealm())
-    UI.drawUpgradeTree(Upgrades.getNodes()) 
+    UI.drawUpgradeTree(Upgrades.getNodes(), Upgrades.effectParams) -- Pass effectParams
 end
 
 function love.keypressed(key)

--- a/player.lua
+++ b/player.lua
@@ -1,14 +1,50 @@
 local Player = {}
 
 Player.data = {
-    x = 400, y = 300, speed = 200, radius = 15,
-    hp = 100, maxHp = 100, exp = 0, level = 1, kills = 0,
+    x = 400, y = 300, 
+    baseSpeed = 200,      -- Base speed
+    speed = 200,          -- Actual speed, will be calculated
+    radius = 15,
+    baseMaxHp = 100,      -- Base Max HP
+    maxHp = 100,          -- Actual Max HP, will be calculated
+    hp = 100, 
+    exp = 0, level = 1, kills = 0,
     gold = 0, essence = {tier1 = 0, tier2 = 0},
-    bonusDamage = 0, bonusCooldown = 0
+    calculatedBonuses = {} -- This will be populated by Upgrades.recalculatePlayerBonuses
+    -- Removed old bonusDamage, bonusCooldown as they are now derived
 }
 
+function Player.applyCalculatedBonuses()
+    local bonuses = Player.data.calculatedBonuses
+    if not bonuses then return end -- Should not happen if called after recalculate
+
+    -- Store old maxHp to calculate difference for current hp adjustment
+    local oldMaxHp = Player.data.maxHp
+
+    -- Max HP
+    Player.data.maxHp = Player.data.baseMaxHp + (bonuses.HP_MAX or 0)
+
+    -- Adjust current HP based on maxHP change
+    local diffMaxHp = Player.data.maxHp - oldMaxHp
+    if diffMaxHp > 0 then
+        Player.data.hp = Player.data.hp + diffMaxHp -- Increase current HP by the amount max HP increased
+    end
+    Player.data.hp = math.min(Player.data.hp, Player.data.maxHp) -- Ensure current HP doesn't exceed new max HP
+    if Player.data.hp <=0 and Player.data.maxHp > 0 then -- Edge case: if player was dead and maxHP increased
+        Player.data.hp = 1 -- Give 1 hp to prevent staying dead with positive maxHP
+    end
+
+
+    -- Speed
+    Player.data.speed = Player.data.baseSpeed * (1 + (bonuses.MOVE_SPEED or 0) / 100)
+
+    -- Other stats like damage and cooldown are used directly from calculatedBonuses in game.lua
+    -- So no need to set specific Player.data.bonusDamage or Player.data.bonusCooldown here.
+    -- print(string.format("Applied Bonuses: New MaxHP=%.2f, New Speed=%.2f", Player.data.maxHp, Player.data.speed))
+end
+
 function Player.update(dt)
-    -- Player movement logic
+    -- Player movement logic uses Player.data.speed which is now updated by applyCalculatedBonuses
     if love.keyboard.isDown("w") then Player.data.y = Player.data.y - Player.data.speed * dt end
     if love.keyboard.isDown("s") then Player.data.y = Player.data.y + Player.data.speed * dt end
     if love.keyboard.isDown("a") then Player.data.x = Player.data.x - Player.data.speed * dt end
@@ -16,8 +52,7 @@ function Player.update(dt)
 end
 
 function Player.draw()
-    -- Player drawing logic
-    love.graphics.setColor(0, 1, 1) -- Player color
+    love.graphics.setColor(0, 1, 1) 
     love.graphics.circle("fill", Player.data.x, Player.data.y, Player.data.radius)
 end
 


### PR DESCRIPTION
ENG- This commit introduces a new upgrade system based on exponential soft-cap scaling, replacing the previous linear bonus calculations.

Key changes:

- **New Scaling Formula:**
    - Upgrade effects are now calculated using `value = base * (1 - falloff^totalLevel)`.
    - `totalLevel` is the sum of levels from all nodes of the same effect type.
    - `base` and `falloff` parameters are configurable per effect type (e.g., "DMG", "CDR", "HP_MAX", "MOVE_SPEED") in `Upgrades.effectParams`.

- **Maxed Node Bonus:**
    - Nodes reaching `maxLevel` (level 10) now contribute an additional +3 to their effect's `totalLevel` for calculation purposes.
    - These nodes are marked with `node.maxed = true`.

- **Centralized Bonus Calculation:**
    - `Upgrades.recalculatePlayerBonuses` now calculates `totalLevels` for each effect type and applies the new formula to populate `Player.data.calculatedBonuses`.
    - Old `node.level * x` logic has been removed.

- **Player Stat Integration:**
    - `Player.applyCalculatedBonuses` updates core player stats (Max HP, Speed) based on `calculatedBonuses`.
    - Combat mechanics in `game.lua` (damage, cooldown) now use values from `Player.data.calculatedBonuses` and defined base stats (e.g., `BASE_PROJECTILE_DAMAGE`).

- **UI Enhancements:**
    - Maxed-out upgrade nodes are now visually distinguished with a golden color in the upgrade tree.
    - Tooltips for maxed nodes display " (MAXED +3)" next to the level.
    - Tooltips now show more descriptive effect names (e.g., "Damage Bonus" instead of "DMG") by using `Upgrades.effectParams`.

This overhaul provides a more balanced and infinitely scalable upgrade progression, enhances player feedback through improved UI, and sets a robust foundation for future gameplay features as outlined for v0.3.0.

POL- To zatwierdzenie wprowadza nowy system ulepszeń oparty na wykładniczym skalowaniu soft-cap, zastępujący poprzednie liniowe obliczenia premii.

Najważniejsze zmiany:

- **Nowa formuła skalowania:**
- Efekty ulepszeń są teraz obliczane przy użyciu `wartość = podstawa * (1 - spadek^totalLevel)`.
- `totalLevel` to suma poziomów wszystkich węzłów tego samego typu efektu.
    - Parametry `base` i `falloff` można konfigurować dla każdego typu efektu (np. „DMG”, „CDR”, »HP_MAX«, „MOVE_SPEED”) w `Upgrades.effectParams`.

- **Premia za maksymalny węzeł:**
    - Węzły osiągające `maxLevel` (poziom 10) teraz dodają dodatkowe +3 do `totalLevel` swojego efektu do celów obliczeniowych.
    - Węzły te są oznaczone jako `node.maxed = true`.

- **Scentralizowane obliczanie premii:**
- `Upgrades.recalculatePlayerBonuses` oblicza teraz `totalLevels` dla każdego typu efektu i stosuje nową formułę do wypełnienia `Player.data.calculatedBonuses`.
- Stara logika `node.level * x` została usunięta.

- **Integracja statystyk gracza:**
    - `Player.applyCalculatedBonuses` aktualizuje podstawowe statystyki gracza (maksymalne HP, prędkość) na podstawie `calculatedBonuses`.
- Mechanika walki w `game.lua` (obrażenia, czas odnowienia) wykorzystuje teraz wartości z `Player.data.calculatedBonuses` i zdefiniowane statystyki podstawowe (np. `BASE_PROJECTILE_DAMAGE`).

- **Ulepszenia interfejsu użytkownika:**
    - Maksymalnie ulepszone węzły są teraz wizualnie wyróżnione złotym kolorem w drzewku ulepszeń.
- Podpowiedzi dla maksymalnie ulepszonych węzłów wyświetlają „ (MAXED +3)” obok poziomu.
    - Podpowiedzi zawierają teraz bardziej opisowe nazwy efektów (np. „Premia do obrażeń” zamiast „DMG”) dzięki użyciu `Upgrades.effectParams`.

Ta zmiana zapewnia bardziej zrównoważony i nieskończenie skalowalny postęp ulepszeń, poprawia informacje zwrotne dla graczy dzięki ulepszonemu interfejsowi użytkownika oraz tworzy solidną podstawę dla przyszłych funkcji rozgrywki, zgodnie z opisem dla wersji 0.3.0.