### PR TITLE
Fix: Improve robustness against missing graphical assets

### DIFF
--- a/assets.lua
+++ b/assets.lua
@@ -1,47 +1,43 @@
 local Assets = {}
 
--- Path prefix for convenience
-local gfxPath = "assets/graphics/" -- Assuming all graphics are in this subfolder
+local gfxPath = "assets/graphics/"
+
+local function loadImage(path)
+    local fullPath = gfxPath .. path
+    local status_ok, image_or_error = pcall(love.graphics.newImage, fullPath)
+    if status_ok then
+        return image_or_error
+    else
+        print("Warning: Failed to load image at '" .. fullPath .. "'. Error: " .. tostring(image_or_error))
+        return nil
+    end
+end
 
 -- Player
--- Assuming a single spritesheet for the player. Animation/quads will be handled later.
-Assets.player_spritesheet = love.graphics.newImage(gfxPath .. "wizard_spritesheet.png")
+Assets.player_spritesheet = loadImage("wizard_spritesheet.png")
 
 -- Projectiles
-Assets.projectile_blue = love.graphics.newImage(gfxPath .. "projectile_blue.png")
+Assets.projectile_blue = loadImage("projectile_blue.png")
 
--- Enemies (store them in a sub-table for organization)
+-- Enemies
 Assets.enemies = {
-    slime = love.graphics.newImage(gfxPath .. "slime.png"),
-    skeleton = love.graphics.newImage(gfxPath .. "skeleton.png"),
-    bird = love.graphics.newImage(gfxPath .. "bird.png"),
-    zombie = love.graphics.newImage(gfxPath .. "zombie.png"),
-    treant = love.graphics.newImage(gfxPath .. "treant.png")
+    slime = loadImage("slime.png"),
+    skeleton = loadImage("skeleton.png"),
+    bird = loadImage("bird.png"),
+    zombie = loadImage("zombie.png"),
+    treant = loadImage("treant.png")
 }
 
--- Loot (store in a sub-table)
+-- Loot
 Assets.loot = {
-    coin = love.graphics.newImage(gfxPath .. "coin.png"),
-    essence_t1 = love.graphics.newImage(gfxPath .. "essence_green.png"), -- Mapping tier1 to green
-    -- essence_t2 = love.graphics.newImage(gfxPath .. "essence_blue.png") -- Example if a blue essence existed
+    coin = loadImage("coin.png"),
+    essence_t1 = loadImage("essence_green.png")
+    -- essence_t2 will be handled by fallback color in Game.draw() as it has no sprite
 }
 
--- UI elements or other specific assets can be added here as needed
--- Example:
+-- Example for UI or other assets if they were images:
 -- Assets.ui = {
---    inventory_panel = love.graphics.newImage(gfxPath .. "inventory_panel.png")
+--    inventory_panel = loadImage("inventory_panel.png")
 -- }
-
--- Upgrade Tree Node Orbs:
--- The prompt indicates these are primarily color-coded circles drawn directly.
--- If specific images were to be used for different node states (e.g., maxed, category),
--- they would be loaded here like:
--- Assets.node_orbs = {
---     offense = love.graphics.newImage(gfxPath .. "orb_red.png"),
---     defense = love.graphics.newImage(gfxPath .. "orb_blue.png"),
---     support = love.graphics.newImage(gfxPath .. "orb_green.png"),
---     maxed_overlay = love.graphics.newImage(gfxPath .. "orb_max_overlay.png")
--- }
--- For now, this section is illustrative, as direct drawing with colors is used.
 
 return Assets

--- a/game.lua
+++ b/game.lua
@@ -35,29 +35,26 @@ function Game.getRealmsTable()
 end
 
 function Game.dropLoot(x, y, playerData)
-    -- Player.data modification remains the same
     if math.random() < 0.5 then
         playerData.gold = playerData.gold + 1
-        table.insert(Game.loot, {x=x,y=y, type="coin", radius=8}) -- Use "coin", set a default radius
+        table.insert(Game.loot, {x=x,y=y, type="coin", radius=8})
     end
     if math.random() < 0.05 then
         playerData.essence.tier1 = playerData.essence.tier1 + 1
-        table.insert(Game.loot, {x=x,y=y, type="essence_t1", radius=8}) -- Use "essence_t1"
+        table.insert(Game.loot, {x=x,y=y, type="essence_t1", radius=8})
     end
     if math.random() < 0.02 then
         playerData.essence.tier2 = playerData.essence.tier2 + 1
-        table.insert(Game.loot, {x=x,y=y, type="essence_t2", radius=8}) -- Keep as "essence_t2"
+        table.insert(Game.loot, {x=x,y=y, type="essence_t2", radius=8})
     end
 end
 
--- playerData here refers to Player.data
 local function calculateBulletDamage(bullet, playerData)
     local damageBonusPercent = (playerData.calculatedBonuses and playerData.calculatedBonuses.DMG) or 0
     return BASE_PROJECTILE_DAMAGE * (1 + damageBonusPercent / 100)
 end
 
 function Game.update(dt, Player, Enemies, config, utils)
-    -- Shooting Logic
     Game.shootCooldown = Game.shootCooldown - dt
 
     local cooldownReductionPercent = (Player.data.calculatedBonuses and Player.data.calculatedBonuses.CDR) or 0
@@ -77,7 +74,6 @@ function Game.update(dt, Player, Enemies, config, utils)
         Game.shootCooldown = actualCooldown
     end
 
-    -- Bullet Update & Boundary Checks
     for i = #Game.bullets, 1, -1 do
         local b = Game.bullets[i]
         if b then
@@ -88,7 +84,6 @@ function Game.update(dt, Player, Enemies, config, utils)
         end
     end
 
-    -- Bullet-Enemy Collision
     for i = #Game.bullets, 1, -1 do
         local b = Game.bullets[i]
         if not b then goto next_bullet_enemy_collision end
@@ -110,7 +105,6 @@ function Game.update(dt, Player, Enemies, config, utils)
         ::next_bullet_enemy_collision::
     end
 
-    -- Bullet-Boss Collision
     local currentBoss = Enemies.getBoss()
     if currentBoss then
         for i = #Game.bullets, 1, -1 do
@@ -139,7 +133,6 @@ function Game.update(dt, Player, Enemies, config, utils)
 end
 
 function Game.draw()
-    -- Draw bullets
     if Assets and Assets.projectile_blue then
         local projectileImage = Assets.projectile_blue
         local pWidth = projectileImage:getWidth()
@@ -149,7 +142,9 @@ function Game.draw()
             love.graphics.draw(projectileImage, b.x, b.y, 0, 1, 1, pWidth / 2, pHeight / 2)
         end
     else
-        print("Warning: Assets.projectile_blue is missing. Drawing circles for bullets.")
+        if Assets then -- Check if Assets table itself exists, even if projectile_blue doesn't
+            print("Warning: Assets.projectile_blue is missing. Drawing circles for bullets.")
+        end
         love.graphics.setColor(1, 1, 0)
         for _, b in ipairs(Game.bullets) do
             love.graphics.circle("fill", b.x, b.y, b.radius or 5)
@@ -157,28 +152,31 @@ function Game.draw()
     end
     love.graphics.setColor(1, 1, 1)
 
-    -- Draw loot
     for _, l in ipairs(Game.loot) do
-        local lootImage = Assets.loot[l.type] -- Try to get specific sprite (e.g., Assets.loot.coin)
+        local lootImage = Assets.loot and Assets.loot[l.type] -- Check Assets.loot exists
+
         if lootImage then
-            love.graphics.setColor(1, 1, 1) -- Ensure sprite is not tinted
+            love.graphics.setColor(1, 1, 1)
             local lWidth = lootImage:getWidth()
             local lHeight = lootImage:getHeight()
             love.graphics.draw(lootImage, l.x, l.y, 0, 1, 1, lWidth / 2, lHeight / 2)
         else
-            -- Fallback for types without specific sprites
-            if l.type == "essence_t2" then
-                love.graphics.setColor(0.2, 0.5, 1) -- Blue for Tier 2 essence
-                love.graphics.circle("fill", l.x, l.y, l.radius or 5)
-            else
-                -- Fallback for any other unknown loot type
-                love.graphics.setColor(1, 0, 1) -- Magenta
-                love.graphics.circle("fill", l.x, l.y, l.radius or 5)
-                print("Warning: Missing sprite for loot type: " .. (l.type or "unknown") .. ". Drawing magenta circle.")
+            if Assets and Assets.loot then -- Only print warning if Assets.loot table itself was expected
+                 print("Info: No sprite for loot type: " .. (l.type or "unknown") .. ". Drawing fallback circle.")
             end
+            if l.type == "coin" then
+                love.graphics.setColor(1, 0.84, 0) -- Gold/Yellow for coin fallback
+            elseif l.type == "essence_t1" then
+                love.graphics.setColor(0, 1, 0) -- Green for Tier 1 essence fallback
+            elseif l.type == "essence_t2" then
+                love.graphics.setColor(0.2, 0.5, 1) -- Blue for Tier 2 essence (current design)
+            else
+                love.graphics.setColor(1, 0, 1) -- Magenta for other unknown loot types
+            end
+            love.graphics.circle("fill", l.x, l.y, l.radius or 5)
         end
     end
-    love.graphics.setColor(1, 1, 1) -- Reset color after drawing all loot
+    love.graphics.setColor(1, 1, 1)
 end
 
 function Game.resetForNewRealm(Player, Enemies)


### PR DESCRIPTION
This commit addresses crashes caused by missing image files.

- Modified `assets.lua` to wrap all `love.graphics.newImage()` calls in `pcall`. If an image fails to load, a warning is printed, and the corresponding asset entry remains `nil` instead of causing a crash.
- Ensured that drawing functions in `player.lua`, `enemies.lua`, and `game.lua` (for projectiles and loot) have fallbacks to drawing colored placeholder circles if their expected sprite assets are `nil`.
- Loot drawing in `game.lua` now has specific colored circle fallbacks for "coin" (yellow) and "essence_t1" (green) if their sprites are missing, in addition to the existing "essence_t2" (blue) fallback.

The game will now load and run even if sprite files are missing from the `assets/graphics/` directory, defaulting to placeholder visuals and printing warnings to the console.