### PR TITLE
feat: Revamp upgrade tree and player sprites

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,3 +1,5 @@
+local upgradeTreeCameraSpeed = 300 -- pixels per second for tree camera movement
+
 function love.load()
     -- Load core modules first
     Config = require("config") -- Made global with capital
@@ -43,6 +45,23 @@ function love.update(dt)
 
     -- Game.update handles bullets, collisions (which then calls Enemies.damage... with callbacks), loot, level up etc.
     Game.update(dt, Player, Enemies, Config, utils) -- Pass global Config
+
+    -- Continuous camera movement for upgrade tree
+    if UI.state.showUpgradeTree then -- Check if tree is visible
+        local moveAmount = upgradeTreeCameraSpeed * dt
+        if love.keyboard.isDown("left") then
+            UI.moveUpgradeTreeCamera(-moveAmount, 0) -- To see left, decrease offset.x
+        end
+        if love.keyboard.isDown("right") then
+            UI.moveUpgradeTreeCamera(moveAmount, 0) -- To see right, increase offset.x
+        end
+        if love.keyboard.isDown("up") then
+            UI.moveUpgradeTreeCamera(0, -moveAmount) -- To see up, decrease offset.y
+        end
+        if love.keyboard.isDown("down") then
+            UI.moveUpgradeTreeCamera(0, moveAmount) -- To see down, increase offset.y
+        end
+    end
 end
 
 function love.draw()
@@ -81,22 +100,6 @@ function love.keypressed(key)
     -- Changed elseif to if for the 'c' key to make it an independent condition
     if key == "c" then
         Player.craftTier2Essence()
-    end
-
-    if key == "left" then
-        UI.moveUpgradeTreeCamera(20, 0)
-    end
-
-    if key == "right" then
-        UI.moveUpgradeTreeCamera(-20, 0)
-    end
-
-    if key == "up" then
-        UI.moveUpgradeTreeCamera(0, 20)
-    end
-
-    if key == "down" then
-        UI.moveUpgradeTreeCamera(0, -20)
     end
 end
 

--- a/player.lua
+++ b/player.lua
@@ -17,10 +17,10 @@ Player.data = {
 Player.quads = {}
 
 function Player.initializeAnimation(playerSheetAsset)
-    Player.quads = {}
+    Player.quads = {} -- Clear existing quads
     if not playerSheetAsset then
         print("Error in Player.initializeAnimation: playerSheetAsset is nil. Cannot create quads.")
-        Player.quads["DEFAULT"] = nil -- Explicitly mark as problematic
+        Player.quads["DEFAULT"] = nil
         return
     end
 
@@ -34,7 +34,7 @@ function Player.initializeAnimation(playerSheetAsset)
     end
 
     local frameWidth = sheetWidth / 3
-    local frameHeight = sheetHeight / 3
+    local frameHeight = sheetHeight / 3 -- Assuming 3 rows effectively, even if row 3 of sprites is ignored for definitions
 
     if frameWidth <= 0 or frameHeight <= 0 then
         print("Error in Player.initializeAnimation: Calculated frameWidth or frameHeight is zero or negative. frameW:", frameWidth, "frameH:", frameHeight)
@@ -42,17 +42,23 @@ function Player.initializeAnimation(playerSheetAsset)
         return
     end
 
-    Player.quads["NW"] = love.graphics.newQuad(0, 0, frameWidth, frameHeight, sheetWidth, sheetHeight)
-    Player.quads["N"]  = love.graphics.newQuad(frameWidth, 0, frameWidth, frameHeight, sheetWidth, sheetHeight)
-    Player.quads["NE"] = love.graphics.newQuad(frameWidth * 2, 0, frameWidth, frameHeight, sheetWidth, sheetHeight)
-    Player.quads["W"]  = love.graphics.newQuad(0, frameHeight, frameWidth, frameHeight, sheetWidth, sheetHeight)
-    Player.quads["S"]  = love.graphics.newQuad(frameWidth, frameHeight, frameWidth, frameHeight, sheetWidth, sheetHeight)
-    Player.quads["E"]  = love.graphics.newQuad(frameWidth * 2, frameHeight, frameWidth, frameHeight, sheetWidth, sheetHeight)
-    Player.quads["SW"] = love.graphics.newQuad(0, frameHeight * 2, frameWidth, frameHeight, sheetWidth, sheetHeight)
-    Player.quads["SE"] = love.graphics.newQuad(frameWidth * 2, frameHeight * 2, frameWidth, frameHeight, sheetWidth, sheetHeight)
+    -- Row 1: N, S, W
+    Player.quads["N"] = love.graphics.newQuad(frameWidth * 0, 0, frameWidth, frameHeight, sheetWidth, sheetHeight)
+    Player.quads["S"] = love.graphics.newQuad(frameWidth * 1, 0, frameWidth, frameHeight, sheetWidth, sheetHeight)
+    Player.quads["W"] = love.graphics.newQuad(frameWidth * 2, 0, frameWidth, frameHeight, sheetWidth, sheetHeight)
+
+    -- Row 2: E, SE, E (second E from issue description)
+    Player.quads["E"] = love.graphics.newQuad(frameWidth * 0, frameHeight, frameWidth, frameHeight, sheetWidth, sheetHeight)
+    Player.quads["SE"] = love.graphics.newQuad(frameWidth * 1, frameHeight, frameWidth, frameHeight, sheetWidth, sheetHeight)
+    Player.quads["E_ALT"] = love.graphics.newQuad(frameWidth * 2, frameHeight, frameWidth, frameHeight, sheetWidth, sheetHeight) -- This is the 3rd frame of row 2
+
+    -- Define fallbacks for diagonal directions not explicitly in the new layout
+    Player.quads["NE"] = Player.quads["E"] -- Fallback for North-East
+    Player.quads["SW"] = Player.quads["W"] -- Fallback for South-West
+    Player.quads["NW"] = Player.quads["W"] -- Fallback for North-West
 
     Player.quads["DEFAULT"] = Player.quads["S"]
-    print("Player animation quads initialized. Frame W/H:", frameWidth, frameHeight)
+    print("Player animation quads initialized according to new layout. Frame W/H:", frameWidth, frameHeight)
 end
 
 function Player.applyCalculatedBonuses()


### PR DESCRIPTION
This commit implements several changes to the upgrade tree and player character systems based on your feedback.

Upgrade Tree:
- **Scaling and Centralization:** Reduced initial node offsets and expansion distances in `upgrades.lua` to make the tree more compact and centered. Base values were approximately halved.
- **Expansion Trigger:** Node expansion now occurs when a node reaches level 5, instead of requiring max level. Nodes can still be upgraded to max level for further benefits.
- **Two-Path Spawning:** `Upgrades.expandTree` now attempts to spawn two child nodes.
- **Outward Expansion:** New nodes are positioned by radiating outwards from the parent node relative to the tree's center, with a configurable spread angle. This replaces the previous category-based directional expansion.
- **Continuous Camera Movement:** Implemented smooth, continuous camera panning for the upgrade tree view in `main.lua` when holding arrow keys. Removed old single-step movement.

Player Sprite:
- **Animation Quads:** Updated `Player.initializeAnimation` in `player.lua` to match the specified 2-row, 6-frame sprite layout:
    - Row 1: N, S, W
    - Row 2: E, SE, E (third frame also 'E')
- Fallbacks for diagonal movements (NE, SW, NW) have been mapped to existing cardinal/diagonal sprites (E or W).

These changes aim to improve the usability and presentation of the upgrade system and align the player character's appearance with the intended design.