### PR TITLE
feat: Implement triangular upgrade tree and enemy health bars

### DIFF
--- a/enemies.lua
+++ b/enemies.lua
@@ -21,21 +21,25 @@ function Enemies.spawnRegularEnemy(realmNumber)
     local y = math.random((Config and Config.windowHeight) or 600)
 
     local enemySpriteKey = availableEnemySpriteKeys[math.random(#availableEnemySpriteKeys)]
-
+    local initialHp = 30 * mult
     table.insert(Enemies.list, {
         x = x, y = y,
         radius = 12,
         speed = 60,
-        hp = 30 * mult,
+        hp = initialHp,
+        maxHp = initialHp, -- Add this line
         exp = 10 * mult,
         spriteKey = enemySpriteKey,
     })
 end
 
 function Enemies.spawnBoss()
+    local initialBossHp = 1000
     Enemies.boss = {
         x = 400, y = 50, radius = 40, speed = 40,
-        hp = 1000, exp = 500,
+        hp = initialBossHp,
+        maxHp = initialBossHp, -- Add this line
+        exp = 500,
         spriteKey = nil
     }
     Enemies.bossSpawned = true
@@ -77,6 +81,14 @@ function Enemies.draw()
         print("Warning: Config not available in Enemies.draw(), using default scale 1.")
     end
 
+    -- Health Bar properties
+    local healthBarHeight = 5
+    local healthBarYOffset = 7 -- Adjusted offset
+    local healthBarBgColor = {0.3, 0.1, 0.1, 0.8} -- Darker Red
+    local healthBarFgColor = {0.8, 0.2, 0.2, 0.9} -- Brighter Red
+    local healthBarBorderColor = {0.1, 0.1, 0.1, 1} -- Black border
+    local healthBarBorderSize = 0.5 -- pixels for border
+
     for _, enemy in ipairs(Enemies.list) do
         if Assets and Assets.enemies and Assets.enemies[enemy.spriteKey] then
             local enemyImage = Assets.enemies[enemy.spriteKey]
@@ -89,24 +101,84 @@ function Enemies.draw()
             end
             love.graphics.setColor(1, 0, 0)
             love.graphics.circle("fill", enemy.x, enemy.y, enemy.radius or 12)
-            love.graphics.setColor(1, 1, 1)
+            love.graphics.setColor(1, 1, 1) -- Reset color after drawing fallback
+        end
+
+        -- After drawing sprite:
+        if enemy.hp and enemy.maxHp and enemy.maxHp > 0 then
+            local hpPercent = math.max(0, math.min(1, enemy.hp / enemy.maxHp))
+
+            local spriteOriginalHeight = 0
+            if Assets and Assets.enemies and Assets.enemies[enemy.spriteKey] then
+                 spriteOriginalHeight = Assets.enemies[enemy.spriteKey]:getHeight()
+            else
+                 spriteOriginalHeight = (enemy.radius or 12) * 2 -- Fallback if no sprite
+            end
+            local scaledSpriteHalfHeight = (spriteOriginalHeight * currentEnemyScale) / 2
+
+            local barWidth = (enemy.radius or 12) * 2.0 -- Bar width based on enemy radius
+            local barX = enemy.x - barWidth / 2
+            local barY = enemy.y - scaledSpriteHalfHeight - healthBarYOffset
+
+            love.graphics.setColor(unpack(healthBarBorderColor))
+            love.graphics.rectangle("fill", barX - healthBarBorderSize, barY - healthBarBorderSize, barWidth + 2*healthBarBorderSize, healthBarHeight + 2*healthBarBorderSize)
+
+            love.graphics.setColor(unpack(healthBarBgColor))
+            love.graphics.rectangle("fill", barX, barY, barWidth, healthBarHeight)
+
+            love.graphics.setColor(unpack(healthBarFgColor))
+            love.graphics.rectangle("fill", barX, barY, barWidth * hpPercent, healthBarHeight)
+
+            love.graphics.setColor(1, 1, 1) -- Reset color after drawing this health bar
         end
     end
+    -- love.graphics.setColor(1, 1, 1) -- This reset is now inside the loop or after boss
 
     if Enemies.boss then
-        -- Assuming boss might use defaultSpriteScale or its own specific scale if defined
-        local bossScale = (Config and Config.defaultSpriteScale) or 1
+        local bossScaleToUse = (Config and Config.defaultSpriteScale) or 1
         if Enemies.boss.spriteKey and Assets and Assets.enemies and Assets.enemies[Enemies.boss.spriteKey] then
             local bossImage = Assets.enemies[Enemies.boss.spriteKey]
             local width = bossImage:getWidth()
             local height = bossImage:getHeight()
-            love.graphics.draw(bossImage, Enemies.boss.x, Enemies.boss.y, 0, bossScale, bossScale, width/2, height/2)
+            love.graphics.draw(bossImage, Enemies.boss.x, Enemies.boss.y, 0, bossScaleToUse, bossScaleToUse, width/2, height/2)
         else
             love.graphics.setColor(0.5, 0, 0)
-            love.graphics.circle("fill", Enemies.boss.x, Enemies.boss.y, Enemies.boss.radius)
+            love.graphics.circle("fill", Enemies.boss.x, Enemies.boss.y, Enemies.boss.radius or 40)
+            love.graphics.setColor(1, 1, 1) -- Reset color after drawing fallback
         end
-        love.graphics.setColor(1, 1, 1)
+
+        -- After drawing boss sprite:
+        if Enemies.boss.hp and Enemies.boss.maxHp and Enemies.boss.maxHp > 0 then
+            local bossHpPercent = math.max(0, math.min(1, Enemies.boss.hp / Enemies.boss.maxHp))
+            local bossScaledRadius = (Enemies.boss.radius or 40)
+
+            local bossBarWidth = bossScaledRadius * 2.0
+            local bossBarX = Enemies.boss.x - bossBarWidth / 2
+
+            local bossSpriteOriginalHeight = 0
+            if Enemies.boss.spriteKey and Assets and Assets.enemies and Assets.enemies[Enemies.boss.spriteKey] then
+                 bossSpriteOriginalHeight = Assets.enemies[Enemies.boss.spriteKey]:getHeight()
+            else
+                 bossSpriteOriginalHeight = (Enemies.boss.radius or 40) * 2 -- Fallback
+            end
+            local bossScaledSpriteHalfHeight = (bossSpriteOriginalHeight * bossScaleToUse) / 2
+
+            local bossBarY = Enemies.boss.y - bossScaledSpriteHalfHeight - (healthBarYOffset + 5) -- Slightly larger offset for boss
+            local bossHealthBarHeight = healthBarHeight + 2 -- Slightly thicker bar for boss
+
+            love.graphics.setColor(unpack(healthBarBorderColor))
+            love.graphics.rectangle("fill", bossBarX - healthBarBorderSize, bossBarY - healthBarBorderSize, bossBarWidth + 2*healthBarBorderSize, bossHealthBarHeight + 2*healthBarBorderSize)
+
+            love.graphics.setColor(unpack(healthBarBgColor))
+            love.graphics.rectangle("fill", bossBarX, bossBarY, bossBarWidth, bossHealthBarHeight)
+
+            love.graphics.setColor(unpack(healthBarFgColor))
+            love.graphics.rectangle("fill", bossBarX, bossBarY, bossBarWidth * bossHpPercent, bossHealthBarHeight)
+
+            love.graphics.setColor(1, 1, 1) -- Reset color after drawing boss health bar
+        end
     end
+    love.graphics.setColor(1, 1, 1) -- Final safety reset
 end
 
 function Enemies.reset()

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -78,37 +78,71 @@ function Upgrades.recalculatePlayerBonuses(Player, nodes)
 end
 
 function Upgrades.initializeTree()
-    Upgrades.nodes = {}
+    Upgrades.nodes = {} -- Clear existing nodes
 
     local uiScale = (Config and Config.uiScaleFactor) or 1
-    if not Config then print("Warning: Global Config not found in Upgrades.initializeTree, using uiScale=1") end
+    if not Config then
+        print("Warning: Global Config not found in Upgrades.initializeTree, using uiScale=1")
+    end
 
     local centerX = (Config and Config.windowWidth or 1920) / 2
     local centerY = (Config and Config.windowHeight or 1080) / 2
 
-    local initialNodeYOffset = 100 * uiScale
-    local initialNodeXOffset = 150 * uiScale
-    local supportNodeYDisplacement = 100 * uiScale
+    -- Define base offsets for the triangular layout
+    -- These values make them "pretty far away"
+    local baseVerticalOffset = 280
+    local baseHorizontalOffset = 320
 
-    local offenseNode = {
-        id = 1, x = centerX - initialNodeXOffset, y = centerY - initialNodeYOffset,
-        level = 0, maxLevel = 10, effect = "DMG", category = "Offense",
-        children = {}, maxed = false
-    }
-    local defenseNode = {
-        id = 2, x = centerX + initialNodeXOffset, y = centerY - initialNodeYOffset,
-        level = 0, maxLevel = 10, effect = "HP_MAX", category = "Defense",
-        children = {}, maxed = false
-    }
+    -- Apply UI scaling to offsets
+    local verticalOffset = baseVerticalOffset * uiScale
+    local horizontalOffset = baseHorizontalOffset * uiScale
+
+    -- Define the three initial nodes with specific categories and positions
+
+    -- Top Node (Support) - Green
     local supportNode = {
-        id = 3, x = centerX, y = (centerY - initialNodeYOffset) + supportNodeYDisplacement, -- Ensure Y is relative to initial line
-        level = 0, maxLevel = 10, effect = "CDR", category = "Support",
-        children = {}, maxed = false
+        id = 1,
+        x = centerX,
+        y = centerY - verticalOffset, -- Positioned towards the top
+        level = 0, maxLevel = 10,
+        effect = "CDR", -- Cooldown Reduction is a common support effect
+        category = "Support",
+        children = {},
+        maxed = false
     }
 
-    table.insert(Upgrades.nodes, offenseNode)
-    table.insert(Upgrades.nodes, defenseNode)
+    -- Bottom-Left Node (Defense) - Blue
+    local defenseNode = {
+        id = 2,
+        x = centerX - horizontalOffset, -- Positioned to the bottom-left
+        y = centerY + verticalOffset,
+        level = 0, maxLevel = 10,
+        effect = "HP_MAX", -- Max HP is a common defense effect
+        category = "Defense",
+        children = {},
+        maxed = false
+    }
+
+    -- Bottom-Right Node (Offense) - Red
+    local offenseNode = {
+        id = 3,
+        x = centerX + horizontalOffset, -- Positioned to the bottom-right
+        y = centerY + verticalOffset,
+        level = 0, maxLevel = 10,
+        effect = "DMG", -- Damage is a common offense effect
+        category = "Offense",
+        children = {},
+        maxed = false
+    }
+
     table.insert(Upgrades.nodes, supportNode)
+    table.insert(Upgrades.nodes, defenseNode)
+    table.insert(Upgrades.nodes, offenseNode)
+
+    print("Upgrades.initializeTree: Created new triangular layout. Top (Support), BL (Defense), BR (Offense).")
+    print("  Support Node (ID 1): x=" .. supportNode.x .. ", y=" .. supportNode.y)
+    print("  Defense Node (ID 2): x=" .. defenseNode.x .. ", y=" .. defenseNode.y)
+    print("  Offense Node (ID 3): x=" .. offenseNode.x .. ", y=" .. offenseNode.y)
 end
 
 function Upgrades.expandTree(nodeToExpand)


### PR DESCRIPTION
This commit introduces two major features based on your feedback:
1. A new triangular layout for the initial upgrade tree nodes.
2. Health bars displayed above enemies.

Upgrade Tree Changes:
- Modified `Upgrades.initializeTree()` in `upgrades.lua`:
    - Initial three nodes are now Support (top-center, Green), Defense (bottom-left, Blue), and Offense (bottom-right, Red).
    - These nodes are positioned significantly further apart using larger base offsets, creating a wide triangular formation.
    - Categories and default effects (CDR, HP_MAX, DMG) are assigned directly during creation.
- Verified color assignments in `ui.lua` align with these categories (Support=Green, Defense=Blue, Offense=Red).
- The existing 'outward from screen center' expansion logic in `Upgrades.expandTree` will apply to these new initial positions.

Enemy Health Bar Changes:
- Modified `enemies.lua`:
    - Enemies (regular and boss) now store `maxHp` alongside `hp`, initialized at spawn.
    - `Enemies.draw()` function updated to render health bars above each enemy and the boss.
    - Health bars include a background, a foreground (representing HP percentage), and a border.
    - Positioning is calculated to be above the enemy's scaled sprite.
    - Colors are themed red for enemy health.