### PR TITLE
fix: Further reduce visual size of coin sprites

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -11,7 +11,7 @@ local config = {
     playerScale = 0.5,       -- Overall scale for the player sprite (wizard_spritesheet.png is 256x256, so 0.5 makes it 128x128)
     enemyScale = 0.25,       -- Original value was 0.5 / 3 (approx 0.166). Adjusted for better visibility.
     projectileScale = 0.35,  -- Original value was 0.5 / 8 (0.0625). Adjusted for better visibility.
-    coinScale = 0.3,         -- Changed from 0.5 to 0.3
+    coinScale = 0.15,        -- Changed from 0.3 to 0.15
 
     defaultSpriteScale = 0.5, -- For other sprites like essences, or as a general fallback if a specific scale isn't defined.
                             -- Note: The original `spriteScale = 0.5` might have been intended as this default.


### PR DESCRIPTION
Per your feedback, the `coinScale` in `config.lua` has been adjusted from 0.3 to 0.15. This makes the coin loot items appear significantly smaller in the game world.